### PR TITLE
Fetch actual org data, pass redirect URL, make session work

### DIFF
--- a/constants/endpoints.js
+++ b/constants/endpoints.js
@@ -1,3 +1,7 @@
+import { stringify } from 'querystring';
+
 const GIT_SCRY_API_BASE = 'http://localhost:1337';
 
 export const GIT_SCRY_CHECK_LOGGED_IN = `${GIT_SCRY_API_BASE}/github-login-check`;
+export const GIT_SCRY_GET_ORGANIZATIONS = `${GIT_SCRY_API_BASE}/github-organizations`;
+export const GIT_SCRY_LOGIN_URL = `${GIT_SCRY_API_BASE}/github-login?${stringify({ redirect: 'http://localhost:3000/organizations' })}`;

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,13 +6,24 @@ import {
   Col,
 } from 'react-grid-system';
 import fetch from 'isomorphic-unfetch';
-import { GIT_SCRY_CHECK_LOGGED_IN } from '../constants/endpoints';
+import {
+  GIT_SCRY_CHECK_LOGGED_IN,
+  GIT_SCRY_LOGIN_URL,
+} from '../constants/endpoints';
 import App from '../components/App';
 import Card from '../components/Card';
 
 class Index extends Component {
-  static async getInitialProps() {
-    const response = await fetch(GIT_SCRY_CHECK_LOGGED_IN);
+  static async getInitialProps(ctx) {
+    const response = await fetch(
+      GIT_SCRY_CHECK_LOGGED_IN,
+      {
+        headers: {
+          cookie: ctx.req.headers.cookie,
+        },
+      },
+    );
+
     const { loggedIn } = await response.json();
 
     return { loggedIn };
@@ -31,6 +42,7 @@ class Index extends Component {
               </Col>
               <Col>
                 <p>YEET.js</p>
+                <a href={GIT_SCRY_LOGIN_URL}>WOAH</a>
               </Col>
             </Row>
           </Card>

--- a/pages/organizations.js
+++ b/pages/organizations.js
@@ -48,6 +48,7 @@ class Organizations extends Component {
 
               return (
                 <OrganizationCard
+                  key={id}
                   id={id}
                   login={login}
                   avatarUrl={avatarUrl}

--- a/pages/organizations.js
+++ b/pages/organizations.js
@@ -1,25 +1,23 @@
 import React, { Component } from 'react';
 import styled from 'styled-components';
 import { Container, Row, Col } from 'react-grid-system';
+import fetch from 'isomorphic-unfetch';
+import { GIT_SCRY_GET_ORGANIZATIONS } from '../constants/endpoints';
 import App from '../components/App';
 import OrganizationCard from '../components/OrganizationCard';
 
 class Organizations extends Component {
-  static async getInitialProps() {
-    const organizations = [
+  static async getInitialProps(ctx) {
+    const response = await fetch(
+      GIT_SCRY_GET_ORGANIZATIONS,
       {
-        "id": 2824164,
-        "login": "hackreactor",
-        "avatar_url": "https://avatars3.githubusercontent.com/u/2824164?v=4",
-        "description": ""
+        headers: {
+          cookie: ctx.req.headers.cookie,
+        },
       },
-      {
-        "id": 4503814,
-        "login": "narvar",
-        "avatar_url": "https://avatars0.githubusercontent.com/u/4503814?v=4",
-        "description": ""
-      }
-    ];
+    );
+
+    const organizations = await response.json();
 
     return { organizations };
   }


### PR DESCRIPTION
This PR:
1. Replaces Organizations page stub data with an actual fetch
2. Sends the Organizations page URL as a param to the `github-login` route for redirection
3. Uses `getInitialProps` in order to pass the `next.js` request cookies when the `git-scry` endpoints are hit -- this is needed to make `express-session` work properly, since the cookies contain the session ID
